### PR TITLE
Update dd.css

### DIFF
--- a/SourceCodes/src/dd.css
+++ b/SourceCodes/src/dd.css
@@ -10,6 +10,12 @@
     --chat-scrollbar-width: 12px;
     --scrollbar-thumb: #666;
     --scrollbar-thumb-hover: #aaa7a7;
+    --settings-blurple: #c47cff;
+    --speaking-ring: hsla(0, 0%, 93%, 0.75);
+    --mentioned-before: rgba(95, 95, 95, 1);
+    --mentioned: rgba(95, 95, 95, 0.1);
+    --mentioned-hover: rgba(95, 95, 95, 0.2);
+}
 }
 /* Core */
 #app-mount, .typeWindows-1za-n7 {
@@ -2292,4 +2298,99 @@ svg polyline[stroke="#7289da"] {
 }
 .contentWrapper-SvZHNd {
   background: var(--background-floating);
+}
+
+.mentioned-xhSam7:before {
+  background: var(--mentioned-before) !important;
+}
+.mentioned-xhSam7 {
+  background: var(--mentioned) !important;
+}
+.mentioned-xhSam7:hover {
+  background: var(--mentioned-hover) !important;
+}
+
+.avatarSpeaking-2IGMRN {
+  box-shadow: inset 0 0 0 2px var(--speaking-ring),
+    inset 0 0 0 3px var(--background-secondary);
+}
+
+.container-3auIfb[style*="67, 181, 129"],
+.button-38aScr[style*="114, 137, 218"],
+.bd-switch-checked {
+  background: var(--settings-blurple) !important;
+}
+
+.container-3auIfb[style*="67, 181, 129"] .slider-TkfMQL svg path {
+  fill: var(--settings-blurple);
+}
+.radioIconForeground-XwlXQN {
+  fill: var(--settings-blurple) !important;
+}
+.lookOutlined-3sRXeN.colorBrand-3pXr91 {
+  color: var(--settings-blurple);
+  border-color: var(--settings-blurple);
+}
+
+.connectedAccountIcon-3P3V6F[alt*="Battle.net"] {
+  content: url(/assets/3a257c4cab129e956b05bd50047eb0f9.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Facebook"] {
+  content: url(/assets/c926e69c482dac25b8e940db74496813.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="GitHub"] {
+  content: url(/assets/9e2893717851c493b4bff518f8b63ee7.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="League of Legends"] {
+  content: url(/assets/fbbd224a0d94747c102515090682bbe1.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Reddit"] {
+  content: url(/assets/bcc7bc0c0b27f9cbadaa1a47ea79db22.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Spotify"] {
+  content: url(/assets/fe3770614c2658a07dea3ecb286ce745.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Skype"] {
+  content: url(/assets/de5fb9e860729912c65048c1c657e1a3.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Steam"] {
+  content: url(/assets/baf4bdd36b7ef74e8f34b402e66f81f4.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Twitch"] {
+  content: url(/assets/4c1bab3f945269a5c1be0b3a2c177141.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Twitter"] {
+  content: url(/assets/2ac50d286a1c883f28b5149239a8ad36.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="YouTube"] {
+  content: url(/assets/0ef81742942677bcef0bebdfb7061d29.png);
+}
+.connectedAccountIcon-3P3V6F[alt*="Xbox Live"] {
+  content: url(/assets/850ed4fcf5839b7a32651f5959e8511e.png);
+}
+
+.tabBar-2MuP6- {
+  justify-content: center;
+}
+.top-28JiJ-:last-child .item-PXvHYJ:last-child {
+  margin-right: 0;
+}
+
+.headerPlaying-j0WQBV,
+.topSectionPlaying-1J5E4n {
+  z-index: 1;
+  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
+    linear-gradient(to top right, #17181a, #14141f) !important;
+}
+.headerSpotify-zpWxgT,
+.topSectionSpotify-1lI0-P {
+  z-index: 1;
+  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
+    linear-gradient(to top right, #32b054, #35b958) !important;
+}
+.headerStreaming-2FjmGz,
+.topSectionStreaming-1Tpf5X {
+  z-index: 1;
+  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
+    linear-gradient(to top right, #54358c, #593894) !important;
 }

--- a/SourceCodes/src/dd.css
+++ b/SourceCodes/src/dd.css
@@ -10,7 +10,7 @@
     --chat-scrollbar-width: 12px;
     --scrollbar-thumb: #666;
     --scrollbar-thumb-hover: #aaa7a7;
-    --settings-blurple: #c47cff;
+    --settings-blurple: #5f5f5f;
     --speaking-ring: hsla(0, 0%, 93%, 0.75);
     --mentioned-before: rgba(95, 95, 95, 1);
     --mentioned: rgba(95, 95, 95, 0.1);
@@ -2315,23 +2315,26 @@ svg polyline[stroke="#7289da"] {
     inset 0 0 0 3px var(--background-secondary);
 }
 
-.container-3auIfb[style*="67, 181, 129"],
-.button-38aScr[style*="114, 137, 218"],
 .bd-switch-checked {
+  background: var(--settings-blurple);
+}
+.container-3auIfb:not([style*="rgb(114, 118, 125)"]),
+.button-38aScr[style*="114, 137, 218"] {
   background: var(--settings-blurple) !important;
 }
-
-.container-3auIfb[style*="67, 181, 129"] .slider-TkfMQL svg path {
+.radioIconForeground-XwlXQN,
+.container-3auIfb:not([style*="rgb(114, 118, 125)"]) .slider-TkfMQL svg path {
   fill: var(--settings-blurple);
-}
-.radioIconForeground-XwlXQN {
-  fill: var(--settings-blurple) !important;
 }
 .lookOutlined-3sRXeN.colorBrand-3pXr91 {
   color: var(--settings-blurple);
   border-color: var(--settings-blurple);
 }
+.item-26Dhrx[aria-checked="true"] svg {
+  color: var(--settings-blurple);
+}
 
+/* White Connection Icons - Credits to botato#6883 */
 .connectedAccountIcon-3P3V6F[alt*="Battle.net"] {
   content: url(/assets/3a257c4cab129e956b05bd50047eb0f9.png);
 }
@@ -2367,30 +2370,4 @@ svg polyline[stroke="#7289da"] {
 }
 .connectedAccountIcon-3P3V6F[alt*="Xbox Live"] {
   content: url(/assets/850ed4fcf5839b7a32651f5959e8511e.png);
-}
-
-.tabBar-2MuP6- {
-  justify-content: center;
-}
-.top-28JiJ-:last-child .item-PXvHYJ:last-child {
-  margin-right: 0;
-}
-
-.headerPlaying-j0WQBV,
-.topSectionPlaying-1J5E4n {
-  z-index: 1;
-  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
-    linear-gradient(to top right, #17181a, #14141f) !important;
-}
-.headerSpotify-zpWxgT,
-.topSectionSpotify-1lI0-P {
-  z-index: 1;
-  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
-    linear-gradient(to top right, #32b054, #35b958) !important;
-}
-.headerStreaming-2FjmGz,
-.topSectionStreaming-1Tpf5X {
-  z-index: 1;
-  background-image: url(https://cdn.naila.bot/Discord/playing-background.svg),
-    linear-gradient(to top right, #54358c, #593894) !important;
 }


### PR DESCRIPTION
- changes the mentioned color, had to make 3 variables instead of just 1 because css sux or im just dumb
- changes the color of the ring that appears when someone is talking in vc
- changes the color of checkboxes and pretty much every blurple color in the settings page except for the discord nitro tab, couldn't really set it to a color that matches the dd aesthetic so i set the variable to the color i personally use (i use the same color with the speaking ring too)
- sets the color of the connected accounts' icons in the profile to white, can sometimes get confusing but i personally don't mind it i think it suits dd
- centers the tabs in the profile, kinda useless but it looks better imo
- adds a weird cool background thingy to popouts/profiles with rich presence, can definitely be too much for a simplistic theme so idk its kinda cool though

also not all of these are mine, at least not from scratch